### PR TITLE
删除多余的英文原文，删除 for 的错误语法

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,11 +1086,6 @@ bash 中有三种类型的循环。`for`, `while` 和 `until`。
  
 不同的 `for` 语法：
 ```bash
-for x := 1 to 10 do
-begin
-  statements
-end
-
 for name [in list]
 do
   statements that can use $name

--- a/README.md
+++ b/README.md
@@ -995,7 +995,6 @@ ${#varname}     # 返回变量值作为一个字符串的长度
 ```
 
 ## 2.4. Functions
-As in almost any programming language, you can use functions to group pieces of code in a more logical way or practice the divine art of recursion. Declaring a function is just a matter of writing . Calling a function is just like calling another program, you just write its name.
 就像在其它编程语言中那样，您可以使用 function 来以更合乎逻辑的方式聚合代码，或实现递归的神圣艺术。声明一个 function 只需要写下`function my_func { my_code }` ，调用 function 就像调用另外的程序一样，使用方法名称即可。
 
 ```bash


### PR DESCRIPTION
1. `2.4. Functions` 中有一段英文原文，应当删除，保留下面的中文翻译。
2. 删除 for 的错误语法。

如 bash [文档](https://www.gnu.org/software/bash/manual/html_node/Looping-Constructs.html)所写

for 语句只有两种写法

```bash
for name [ [in [words …] ] ; ] do commands; done
```

和

```bash
for (( expr1 ; expr2 ; expr3 )) ; do commands ; done
```

如下 for 语句的写法是错的，应该被删除

```bash
for x := 1 to 10 do
begin
  statements
end
```

# 测试

Mac上测试

```bash
bash-3.2$ bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin22)
Copyright (C) 2007 Free Software Foundation, Inc.
bash-3.2$ cat test.sh 
#!/bin/bash

for x := 1 to 10 do
begin
  echo $x
end
bash-3.2$ ./test.sh 
./test.sh: line 3: syntax error near unexpected token `:='
./test.sh: line 3: `for x := 1 to 10 do'
```